### PR TITLE
loadtest now uses worker threads to run multiple clients in parallel

### DIFF
--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -18,51 +18,50 @@ const config = require('../lib/config');
 
 // init
 const options = stdio.getopt({
-	maxRequests: {key: 'n', args: 1, description: 'Number of requests to perform'},
-	concurrency: {key: 'c', args: 1, description: 'Number of requests to make'},
-	maxSeconds: {key: 't', args: 1, description: 'Max time in seconds to wait for responses'},
-	timeout: {key: 'd', args: 1, description: 'Timeout for each request in milliseconds'},
-	contentType: {key: 'T', args: 1, description: 'MIME type for the body'},
-	cookies: {key: 'C', multiple: true, description: 'Send a cookie as name=value'},
-	headers: {key: 'H', multiple: true, description: 'Send a header as header:value'},
-	postBody: {key: 'P', args: 1, description: 'Send string as POST body'},
-	postFile: {key: 'p', args: 1, description: 'Send the contents of the file as POST body'},
-	patchBody: {key: 'A', args: 1, description: 'Send string as PATCH body'},
-	patchFile: {key: 'a', args: 1, description: 'Send the contents of the file as PATCH body'},
-	data: {args: 1, description: 'Send data POST body'},
-	method: {key: 'm', args: 1, description: 'method to url'},
-	putFile: {key: 'u', args: 1, description: 'Send the contents of the file as PUT body'},
-	requestGenerator: {key: 'R', args: 1, description: 'JS module with a custom request generator function'},
-	recover: {key: 'r', description: 'Do not exit on socket receive errors (default)'},
-	secureProtocol: {key: 's', args: 1, description: 'TLS/SSL secure protocol method to use'},
-	keepalive: {key: 'k', description: 'Use a keep-alive http agent'},
-	version: {key: 'V', description: 'Show version number and exit'},
-	proxy: {args: 1, description: 'Use a proxy for requests e.g. http://localhost:8080 '},	
-	rps: {args: 1, description: 'Specify the requests per second for each client'},
-	agent: {description: 'Use a keep-alive http agent (deprecated)'},
-	index: {args: 1, description: 'Replace the value of given arg with an index in the URL'},
-	quiet: {description: 'Do not log any messages'},
-	debug: {description: 'Show debug messages'},
-	insecure: {description: 'Allow self-signed certificates over https'},
-	key: {args: 1, description: 'The client key to use'},
-	cert: {args: 1, description: 'The client certificate to use'}
+	maxRequests: { key: 'n', args: 1, description: 'Number of requests to perform' },
+	concurrency: { key: 'c', args: 1, description: 'Number of requests to make' },
+	maxSeconds: { key: 't', args: 1, description: 'Max time in seconds to wait for responses' },
+	timeout: { key: 'd', args: 1, description: 'Timeout for each request in milliseconds' },
+	contentType: { key: 'T', args: 1, description: 'MIME type for the body' },
+	cookies: { key: 'C', multiple: true, description: 'Send a cookie as name=value' },
+	headers: { key: 'H', multiple: true, description: 'Send a header as header:value' },
+	postBody: { key: 'P', args: 1, description: 'Send string as POST body' },
+	postFile: { key: 'p', args: 1, description: 'Send the contents of the file as POST body' },
+	patchBody: { key: 'A', args: 1, description: 'Send string as PATCH body' },
+	patchFile: { key: 'a', args: 1, description: 'Send the contents of the file as PATCH body' },
+	data: { args: 1, description: 'Send data POST body' },
+	method: { key: 'm', args: 1, description: 'method to url' },
+	putFile: { key: 'u', args: 1, description: 'Send the contents of the file as PUT body' },
+	requestGenerator: { key: 'R', args: 1, description: 'JS module with a custom request generator function' },
+	recover: { key: 'r', description: 'Do not exit on socket receive errors (default)' },
+	secureProtocol: { key: 's', args: 1, description: 'TLS/SSL secure protocol method to use' },
+	keepalive: { key: 'k', description: 'Use a keep-alive http agent' },
+	version: { key: 'V', description: 'Show version number and exit' },
+	proxy: { args: 1, description: 'Use a proxy for requests e.g. http://localhost:8080 ' },
+	rps: { args: '*', description: 'Specify the requests per second for each client' },
+	// GWU:Custom
+	rpsInterval: { args: 1, description: 'Specify the interval to update the rps value' },
+	url: {args: 1, description: 'Specify the url to loadtest', required: true},
+	agent: { description: 'Use a keep-alive http agent (deprecated)' },
+	index: { args: 1, description: 'Replace the value of given arg with an index in the URL' },
+	quiet: { description: 'Do not log any messages' },
+	debug: { description: 'Show debug messages' },
+	insecure: { description: 'Allow self-signed certificates over https' },
+	key: { args: 1, description: 'The client key to use' },
+	cert: { args: 1, description: 'The client certificate to use' }
 });
 if (options.version) {
 	console.log('Loadtest version: %s', packageJson.version);
 	process.exit(0);
 }
 // is there an url? if not, break and display help
-if (!options.args || options.args.length < 1) {
+if (!options.url) {
 	console.error('Missing URL to load-test');
-	help();
-} else if (options.args.length > 1) {
-	console.error('Too many arguments: %s', options.args);
 	help();
 }
 
 const configuration = config.loadConfig(options);
 
-options.url = options.args[0];
 options.agentKeepAlive = options.keepalive || options.agent || configuration.agentKeepAlive;
 options.indexParam = options.index || configuration.indexParam;
 
@@ -86,7 +85,7 @@ if (options.method) {
 		options.method = 'GET';
 	}
 }
-if(options.putFile) {
+if (options.putFile) {
 	options.method = 'PUT';
 	options.body = readBody(options.putFile, '-u');
 }
@@ -94,31 +93,38 @@ if (options.patchBody) {
 	options.method = 'PATCH';
 	options.body = options.patchBody;
 }
-if(options.patchFile) {
+if (options.patchFile) {
 	options.method = 'PATCH';
 	options.body = readBody(options.patchFile, '-a');
 }
-if(!options.method) {
+if (!options.method) {
 	options.method = configuration.method;
 }
-if(!options.body) {
-	if(configuration.body) {
+if (!options.body) {
+	if (configuration.body) {
 		options.body = configuration.body;
-	} else if(configuration.file) {
+	} else if (configuration.file) {
 		options.body = readBody(configuration.file, 'configuration.request.file');
 	}
 }
-options.requestsPerSecond = options.rps ? parseFloat(options.rps) : configuration.requestsPerSecond;
-if(!options.key) {
+if (options.rpsInterval) {
+	options.rpsInterval = parseFloat(options.rpsInterval);
+}
+if (Array.isArray(options.rps)) {
+	options.requestsPerSecond = options.rps.map((rps) => parseFloat(rps));
+} else {
+	options.requestsPerSecond = options.rps ? parseFloat(options.rps) : configuration.requestsPerSecond;
+}
+if (!options.key) {
 	options.key = configuration.key;
 }
-if(options.key) {
+if (options.key) {
 	options.key = fs.readFileSync(options.key);
 }
-if(!options.cert) {
+if (!options.cert) {
 	options.cert = configuration.cert;
 }
-if(options.cert) {
+if (options.cert) {
 	options.cert = fs.readFileSync(options.cert);
 }
 
@@ -141,34 +147,34 @@ if (options.requestGenerator) {
 }
 
 // Use configuration file for other values
-if(!options.maxRequests) {
+if (!options.maxRequests) {
 	options.maxRequests = configuration.maxRequests;
 }
-if(!options.concurrency) {
+if (!options.concurrency) {
 	options.concurrency = configuration.concurrency;
 }
-if(!options.maxSeconds) {
+if (!options.maxSeconds) {
 	options.maxSeconds = configuration.maxSeconds;
 }
-if(!options.timeout && configuration.timeout) {
+if (!options.timeout && configuration.timeout) {
 	options.timeout = configuration.timeout;
 }
-if(!options.contentType) {
+if (!options.contentType) {
 	options.contentType = configuration.contentType;
 }
-if(!options.cookies) {
+if (!options.cookies) {
 	options.cookies = configuration.cookies;
 }
-if(!options.secureProtocol) {
+if (!options.secureProtocol) {
 	options.secureProtocol = configuration.secureProtocol;
 }
-if(!options.insecure) {
+if (!options.insecure) {
 	options.insecure = configuration.insecure;
 }
-if(!options.recover) {
+if (!options.recover) {
 	options.recover = configuration.recover;
 }
-if(!options.proxy) {
+if (!options.proxy) {
 	options.proxy = configuration.proxy;
 }
 
@@ -180,11 +186,11 @@ function readBody(filename, option) {
 		help();
 	}
 
-	if(path.extname(filename) === '.js') {
+	if (path.extname(filename) === '.js') {
 		return require(path.resolve(filename));
 	}
 
-	const ret = fs.readFileSync(filename, {encoding: 'utf8'}).replace("\n", "");
+	const ret = fs.readFileSync(filename, { encoding: 'utf8' }).replace("\n", "");
 
 	return ret;
 }

--- a/lib/customHttpClient.js
+++ b/lib/customHttpClient.js
@@ -1,50 +1,19 @@
-'use strict';
-
-/**
- * Load Test a URL, website or websocket.
- * (C) 2013 Alex Fernández.
- */
-
-
-// requires
-const testing = require('testing');
-const urlLib = require('url');
+const urlLib = require("url");
 const http = require('http');
 const https = require('https');
-const qs = require('querystring');
-const websocket = require('websocket');
-const Log = require('log');
+const { parentPort } = require("worker_threads");
 const { HighResolutionTimer } = require('./hrtimer.js');
-const headers = require('./headers.js');
-// globals
+const headers = require("./headers.js");
+const Log = require('log');
 const log = new Log('info');
+const { createId } = require("./latency");
 
 
-/**
- * Create a new HTTP client.
- * Seem parameters below.
- */
-exports.create = function (operation, params) {
-	return new HttpClient(operation, params);
-};
-
-/**
- * A client for an HTTP connection.
- * Operation is an object which has these attributes:
- *	- latency: a variable to measure latency.
- *	- running: if the operation is running or not.
- * Params is an object with the same options as exports.loadTest.
- */
-class HttpClient {
-	constructor(operation, params) {
-		this.operation = operation
-		this.params = params
+class CustomHttpClient {
+	constructor(param) {
+		this.params = param;
 		this.init();
 	}
-
-	/**
-	 * Init options and message to send.
-	 */
 	init() {
 		this.options = urlLib.parse(this.params.url);
 		this.options.headers = {};
@@ -104,38 +73,40 @@ class HttpClient {
 		}
 		log.debug('Options: %j', this.options);
 	}
-
-	/**
-	 * Start the HTTP client.
-	 */
 	start() {
-		if (!this.params.requestsPerSecond) {
-			return this.makeRequest();
-		}
-		const interval = 1000 / this.params.requestsPerSecond;
-		this.requestTimer = new HighResolutionTimer(interval, () => this.makeRequest());
+		let index = 0;
+		this.rpsIntervalTimer = new HighResolutionTimer(this.params.rpsInterval * 1000, () => {
+			const rps = this.params.requestsPerSecond[index++ % this.params.requestsPerSecond.length];
+			if (this.params.agentKeepAlive) {
+				this.options.agent.maxSockets = 10 + rps;
+			}
+			// stop the old requesttimer
+			if (this.requestTimer !== undefined) {
+				this.requestTimer.stop();
+			}
+			const interval = 1000 / rps;
+			// start new request timer
+			this.requestTimer = new HighResolutionTimer(interval, () => this.makeRequest());
+		});
 	}
-
-	/**
-	 * Stop the HTTP client.
-	 */
 	stop() {
 		if (this.requestTimer) {
 			this.requestTimer.stop();
 		}
-	}
-
-	/**
-	 * Make a single request to the server.
-	 */
-	makeRequest() {
-		if (!this.operation.running) {
-			return;
+		// GWU:Custom
+		if (this.rpsIntervalTimer) {
+			this.rpsIntervalTimer.stop();
 		}
-		if (this.operation.options.maxRequests && this.operation.requests >= this.operation.options.maxRequests) return
-		this.operation.requests += 1;
-
-		const id = this.operation.latency.start();
+	}
+	makeRequest() {
+		// if (!this.operation.running) {
+		// 	return;
+		// }
+		// if (this.operation.options.maxRequests && this.operation.requests >= this.operation.options.maxRequests) return
+		// this.operation.requests += 1;
+		// log.debug("Request made at: ", process.hrtime()[0]);
+		const id = createId();
+		parentPort.postMessage({ event: "REQ_START", id });
 		const requestFinished = this.getRequestFinisher(id);
 		let lib = http;
 		if (this.options.protocol == 'https:') {
@@ -153,8 +124,6 @@ class HttpClient {
 			const agent = new HttpsProxyAgent(proxy);
 			this.options.agent = agent;
 		}
-
-
 		// Disable certificate checking
 		if (this.params.insecure === true) {
 			process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
@@ -174,15 +143,6 @@ class HttpClient {
 		} else {
 			request = lib.request(this.options, this.getConnect(id, requestFinished, this.params.contentInspector));
 		}
-		if (this.params.timeout) {
-			const timeout = parseInt(this.params.timeout);
-			if (!timeout) {
-				log.error('Invalid timeout %s', this.params.timeout);
-			}
-			request.setTimeout(timeout, () => {
-				requestFinished('Connection timed out');
-			});
-		}
 		if (message) {
 			request.write(message);
 		}
@@ -191,10 +151,6 @@ class HttpClient {
 		});
 		request.end();
 	}
-
-	/**
-	 * Get a function that finishes one request and goes for the next.
-	 */
 	getRequestFinisher(id) {
 		return (error, result) => {
 			let errorCode = null;
@@ -211,29 +167,25 @@ class HttpClient {
 			} else {
 				log.debug('Connection %s ended', id);
 			}
-
-			const elapsed = this.operation.latency.end(id, errorCode);
-			if (elapsed < 0) {
-				// not found or not running
-				return;
-			}
-			const index = this.operation.latency.getRequestIndex(id);
-			if (result) {
-				result.requestElapsed = elapsed;
-				result.requestIndex = index;
-				result.instanceIndex = this.operation.instanceIndex;
-			}
-			let callback;
-			if (!this.params.requestsPerSecond) {
-				callback = this.makeRequest.bind(this);
-			}
-			this.operation.callback(error, result, callback);
+			parentPort.postMessage({ event: "REQ_FIN", id, errorCode });
+			// const elapsed = this.latencyObj.end(id, errorCode);
+			// if (elapsed < 0) {
+			// 	// not found or not running
+			// 	return;
+			// }
+			// const index = this.latencyObj.getRequestIndex(id);
+			// if (result) {
+			// 	result.requestElapsed = elapsed;
+			// 	result.requestIndex = index;
+			// 	// result.instanceIndex = this.operation.instanceIndex;
+			// }
+			// let callback;
+			// if (!this.params.requestsPerSecond) {
+			// 	callback = this.makeRequest.bind(this);
+			// }
+			// this.operation.callback(error, result, callback);
 		};
 	}
-
-	/**
-	 * Get a function to connect the player.
-	 */
 	getConnect(id, callback, contentInspector) {
 		let body = '';
 		return connection => {
@@ -271,28 +223,9 @@ class HttpClient {
 	}
 }
 
-function testHttpClient(callback) {
-	const options = {
-		url: 'http://localhost:7357/',
-		maxSeconds: 0.1,
-		concurrency: 1,
-		quiet: true,
-	};
-	exports.create({}, options);
-	testing.success(callback);
-}
 
-
-/**
- * Run all tests.
- */
-exports.test = function (callback) {
-	testing.run([
-		testHttpClient,
-	], callback);
-};
-
-// run tests if invoked directly
-if (__filename == process.argv[1]) {
-	exports.test(testing.show);
-}
+parentPort.on("message", message => {
+	const options = JSON.parse(message.options);
+	const client = new CustomHttpClient(options);
+	client.start();
+});

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -89,8 +89,8 @@ class Latency {
 		delete this.requests[requestId];
 		//GWU modify
 		if (!errorCode) {
-                        log.info('MULogs:elapsed time:' + elapsed);
-                }
+			log.info('MULogs:elapsed time:' + elapsed);
+		}
 
 		return elapsed;
 	}
@@ -245,8 +245,8 @@ class Latency {
 			log.debug('Histogram for %s: %s', ms, this.histogramMs[ms]);
 			counted += this.histogramMs[ms];
 			//const percent = counted / this.totalRequests * 100;
-                        //GWU modify
-                        const percent = counted / this.totalSuccessRequests * 100;
+			//GWU modify
+			const percent = counted / this.totalSuccessRequests * 100;
 
 			Object.keys(percentiles).forEach(percentile => {
 				log.debug('Checking percentile %s for %s', percentile, percent);
@@ -281,7 +281,9 @@ class Latency {
 		}
 		log.info('Agent:               %s', agent);
 		if (this.options.requestsPerSecond) {
-			log.info('Requests per second: %s', this.options.requestsPerSecond * this.options.concurrency);
+			if (Array.isArray(this.options.requestsPerSecond)) {
+				log.info('Requests per second: %s', this.options.requestsPerSecond.map((rps) => rps * this.options.concurrency));
+			}
 		}
 		log.info('');
 		log.info('Completed requests:  %s', results.totalRequests);
@@ -376,7 +378,7 @@ function testLatencyPercentiles(callback) {
 	});
 	for (let ms = 1; ms <= 10; ms++) {
 		log.debug('Starting %s', ms);
-		(function() {
+		(function () {
 			const id = latency.start();
 			setTimeout(() => {
 				log.debug('Ending %s', id);
@@ -401,6 +403,7 @@ function test(callback) {
 module.exports = {
 	Latency,
 	test,
+	createId,
 }
 
 // run tests if invoked directly

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -8,14 +8,15 @@
 
 // requires
 const Log = require('log');
+const path = require("path");
 const http = require('http');
 const https = require('https');
 const testing = require('testing');
+const { Worker } = require('worker_threads');
 const httpClient = require('./httpClient.js');
 const websocket = require('./websocket.js');
-const {Latency} = require('./latency.js');
-const {HighResolutionTimer} = require('./hrtimer.js');
-
+const { Latency } = require('./latency.js');
+const { HighResolutionTimer } = require('./hrtimer.js');
 // globals
 const log = new Log('info');
 
@@ -47,13 +48,17 @@ https.globalAgent.maxSockets = 1000;
  *	- insecure: allow https using self-signed certs.
  * An optional callback will be called if/when the test finishes.
  */
-exports.loadTest = function(options, callback) {
+
+exports.loadTest = function (options, callback) {
 	if (!options.url) {
 		log.error('Missing URL in options');
 		return;
 	}
 	options.concurrency = options.concurrency || 1;
-	if (options.requestsPerSecond) {
+	// GWU:Custom
+	if (Array.isArray(options.requestsPerSecond)) {
+		options.requestsPerSecond = options.requestsPerSecond.map((rps) => (rps / options.concurrency));
+	} else if (options.requestsPerSecond) {
 		options.requestsPerSecond = options.requestsPerSecond / options.concurrency;
 	}
 	if (options.debug) {
@@ -72,8 +77,12 @@ exports.loadTest = function(options, callback) {
 			log.error('"requestsPerSecond" not supported for WebSockets');
 		}
 	}
-
-	const operation = new Operation(options, callback);
+	let operation;
+	if (options.rpsInterval && Array.isArray(options.requestsPerSecond)) {
+		operation = new CustomOperations(options, callback);
+	} else {
+		operation = new Operation(options, callback);
+	}
 	operation.start();
 	return operation;
 };
@@ -143,17 +152,17 @@ class Operation {
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
 				let oldToken = new RegExp(this.options.indexParam, 'g');
-				if(this.options.indexParamCallback instanceof Function) {
+				if (this.options.indexParamCallback instanceof Function) {
 					let customIndex = this.options.indexParamCallback();
 					this.options.url = url.replace(oldToken, customIndex);
-					if(this.options.body) {
+					if (this.options.body) {
 						let body = strBody.replace(oldToken, customIndex);
 						this.options.body = JSON.parse(body);
 					}
 				}
 				else {
 					this.options.url = url.replace(oldToken, index);
-					if(this.options.body) {
+					if (this.options.body) {
 						let body = strBody.replace(oldToken, index);
 						this.options.body = JSON.parse(body);
 					}
@@ -180,6 +189,86 @@ class Operation {
 	 * Stop clients.
 	 */
 	stop() {
+		if (this.showTimer) {
+			this.showTimer.stop();
+		}
+		if (this.stopTimeout) {
+			clearTimeout(this.stopTimeout);
+		}
+		this.running = false;
+		this.latency.running = false;
+
+		Object.keys(this.clients).forEach(index => {
+			this.clients[index].stop();
+		});
+		if (this.finalCallback) {
+			const result = this.latency.getResults();
+			result.instanceIndex = this.instanceIndex;
+			this.finalCallback(null, result);
+		} else {
+			this.latency.show();
+		}
+	}
+}
+
+
+// GWU: custom
+class CustomOperations extends Operation {
+	constructor(options, callback) {
+		super(options, callback);
+		this.workers = [];
+	}
+	startClients() {
+		const url = this.options.url;
+		const strBody = JSON.stringify(this.options.body);
+		for (let index = 0; index < this.options.concurrency; index++) {
+			if (this.options.indexParam) {
+				let oldToken = new RegExp(this.options.indexParam, 'g');
+				if (this.options.indexParamCallback instanceof Function) {
+					let customIndex = this.options.indexParamCallback();
+					this.options.url = url.replace(oldToken, customIndex);
+					if (this.options.body) {
+						let body = strBody.replace(oldToken, customIndex);
+						this.options.body = JSON.parse(body);
+					}
+				}
+				else {
+					this.options.url = url.replace(oldToken, index);
+					if (this.options.body) {
+						let body = strBody.replace(oldToken, index);
+						this.options.body = JSON.parse(body);
+					}
+				}
+			}
+			// start each client at a random moment in one second
+			const worker = new Worker(path.join(__dirname, "./customHttpClient.js"), {});
+			worker.on('message', (message) => {
+				if (message.event == "REQ_START") {
+					this.reqStart(message.id);
+				}
+				if (message.event == "REQ_FIN") {
+					this.reqStop(message.id, message.errorCode);
+					this.callback();
+				}
+			});
+			worker.on('error', (err) => log.debug(err));
+			worker.on('exit', (code) => {
+				log.debug("worker exit", code);
+			});
+			worker.postMessage({ options: JSON.stringify(this.options) });
+			this.workers.push(worker);
+		}
+	}
+	reqStart(id) {
+		this.latency.start(id);
+	}
+	reqStop(id, errorCode) {
+		this.latency.end(id, errorCode);
+	}
+	stop() {
+		for (let index = 0; index < this.workers.length; index++) {
+			this.workers[index].terminate();
+		}
 		if (this.showTimer) {
 			this.showTimer.stop();
 		}
@@ -232,7 +321,7 @@ function testWSEcho(callback) {
 function testIndexParam(callback) {
 	const options = {
 		url: 'http://localhost:7357/replace',
-		concurrency:1,
+		concurrency: 1,
 		quiet: true,
 		maxSeconds: 0.1,
 		indexParam: "replace"
@@ -243,7 +332,7 @@ function testIndexParam(callback) {
 function testIndexParamWithBody(callback) {
 	const options = {
 		url: 'http://localhost:7357/replace',
-		concurrency:1,
+		concurrency: 1,
 		quiet: true,
 		maxSeconds: 0.1,
 		indexParam: "replace",
@@ -255,11 +344,11 @@ function testIndexParamWithBody(callback) {
 function testIndexParamWithCallback(callback) {
 	const options = {
 		url: 'http://localhost:7357/replace',
-		concurrency:1,
+		concurrency: 1,
 		quiet: true,
 		maxSeconds: 0.1,
 		indexParam: "replace",
-		indexParamCallback: function() {
+		indexParamCallback: function () {
 			//https://gist.github.com/6174/6062387
 			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 		}
@@ -270,12 +359,12 @@ function testIndexParamWithCallback(callback) {
 function testIndexParamWithCallbackAndBody(callback) {
 	const options = {
 		url: 'http://localhost:7357/replace',
-		concurrency:1,
+		concurrency: 1,
 		quiet: true,
 		maxSeconds: 0.1,
 		body: '{"id": "replace"}',
 		indexParam: "replace",
-		indexParamCallback: function() {
+		indexParamCallback: function () {
 			//https://gist.github.com/6174/6062387
 			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 		}
@@ -287,12 +376,11 @@ function testIndexParamWithCallbackAndBody(callback) {
 /**
  * Run all tests.
  */
-exports.test = function(callback) {
+exports.test = function (callback) {
 	testing.run([testMaxSeconds, testWSEcho, testIndexParam, testIndexParamWithBody, testIndexParamWithCallback, testIndexParamWithCallbackAndBody], callback);
 };
 
-// run tests if invoked directly
-if (__filename == process.argv[1]) {
-	exports.test(testing.show);
-}
-
+// // run tests if invoked directly
+// if (__filename == process.argv[1]) {
+// 	exports.test(testing.show);
+// }

--- a/sample/variable-rps.js
+++ b/sample/variable-rps.js
@@ -20,30 +20,16 @@ const options = {
     url: 'http://localhost:8080',
     maxRequests: 10000,
     // headers: { 'Host': 'autoscale-go.default.example.com' },
-    // starting rps
-    requestsPerSecond: 200,
-    concurrency: 1,
-
+    
+    // starting rps can be an array or a single value
+    requestsPerSecond: [400, 600, 800, 1200],
+    concurrency: 10,
+    debug:true,
     /**
      * GWU:Custom parameters
      */
     rpsInterval,
     agentKeepAlive: true,
-    // first option which uses the last value in rps array once it reaches the end. Use whatever version required for tests
-    // updateRPSCallback() {
-    //     // console.log("callback called");
-    //     if (index < rps.length) {
-    //         return rps[index++];
-    //     }
-    //     // if the index >= than length of array select the last index
-    //     else {
-    //         return rps[rps.length - 1];
-    //     }
-    // },
-    // 2nd option which cycles through the rps array once it reaches the end
-    updateRPSCallback() {
-        return rps[index++ % rps.length];
-    },
 };
 
 loadtest.loadTest(options, function (error, result) {


### PR DESCRIPTION
In order to test the changes, run the loadtest script inside the bin folder. 
Example commands on how to run it
`./loadtest.js -n 10000 -c 10 --rps 400 600 800 1000 1200 --rpsInterval 1 --url http://127.0.0.1:8080` 
'./loadtest.js -n 10000 -c 10  --url http://127.0.0.1:8080'

In order to use the custom variable rps and rpsInterval options are required.